### PR TITLE
Implemented Morale and Loyalty systems.

### DIFF
--- a/src/acks.css
+++ b/src/acks.css
@@ -701,6 +701,19 @@
   /*  Item Controls                            */
   /* ----------------------------------------- */
 }
+.acks.sheet.actor.character .sheet-header .header-details .summary .check-field:hover .check {
+  display: inline;
+}
+.acks.sheet.actor.character .sheet-header .header-details .summary .check-field .check {
+  display: none;
+  line-height: 35px;
+  flex: 0 0 20px;
+  position: absolute;
+  font-size: 12px;
+}
+.acks.sheet.actor.character .sheet-header .header-details .summary .check-field .check:hover {
+  color: rgba(0, 0, 0, 0.9);
+}
 .acks.sheet.actor.character .sheet-header .xp-bonus {
   top: -15px;
   right: 3px;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -69,8 +69,8 @@
   "ACKS.Retainer": "Retainer",
   "ACKS.RetainerWage": "Wage",
   "ACKS.RetainerUpkeep": "Upkeep",
-  "ACKS.Loyalty": "Henchmen Morale",
-  "ACKS.LoyaltyShort": "MOR",
+  "ACKS.Loyalty": "Loyalty",
+  "ACKS.LoyaltyShort": "LYL",
 
   "ACKS.scores.str.long": "Strength",
   "ACKS.scores.str.short": "STR",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -290,5 +290,18 @@
   "ACKS.reaction.Unfriendly": "{name} is Unfriendly and may attack",
   "ACKS.reaction.Neutral": "{name} is Neutral and uncertain",
   "ACKS.reaction.Indifferent": "{name} is Indifferent and uninterested",
-  "ACKS.reaction.Friendly": "{name} is Friendly and helpful"
+  "ACKS.reaction.Friendly": "{name} is Friendly and helpful",
+  
+  "ACKS.loyalty.check": "Henchman Loyalty Check",
+  "ACKS.loyalty.hostility": "Becomes Hostile",
+  "ACKS.loyalty.resignation": "Tenders Resignation",
+  "ACKS.loyalty.grudging": "Grudging Loyalty",
+  "ACKS.loyalty.loyal": "Loyal",
+  "ACKS.loyalty.fanatic": "Fanatic Loyalty",
+
+  "ACKS.morale.retreat": "Retreat",
+  "ACKS.morale.fightingWithdrawal": "Fighting Withdrawl",
+  "ACKS.morale.fight": "Fight On",
+  "ACKS.morale.advanceAndPursue": "Advance and Pursue",
+  "ACKS.morale.fightToTheDeath": "Victory or Death"
 }

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -140,6 +140,11 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
+    html.find(".morale-check a").click((ev) => {
+      let actorObject = this.actor;
+      actorObject.rollMorale({ event: event });
+    });
+    
     html.find(".ability-score .attribute-name a").click((ev) => {
       let actorObject = this.actor;
       let element = event.currentTarget;

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -144,6 +144,11 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
       let actorObject = this.actor;
       actorObject.rollMorale({ event: event });
     });
+
+    html.find(".loyalty-check a").click((ev) => {
+      let actorObject = this.actor;
+      actorObject.rollLoyalty({ event: event });
+    });
     
     html.find(".ability-score .attribute-name a").click((ev) => {
       let actorObject = this.actor;

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -162,21 +162,40 @@ export class AcksActor extends Actor {
 
   rollMorale(options = {}) {
     const rollParts = ["2d6"];
+    rollParts.push(this.data.data.details.morale);
 
     const data = {
       actor: this.data,
       roll: {
-        type: "below",
-        target: this.data.data.details.morale,
+        type: "table",
+        table: {
+          1: game.i18n.format("ACKS.morale.retreat", {
+            name: this.data.name,
+          }),
+          3: game.i18n.format("ACKS.morale.fightingWithdrawal", {
+            name: this.data.name,
+          }),
+          6: game.i18n.format("ACKS.morale.fight", {
+            name: this.data.name,
+          }),
+          9: game.i18n.format("ACKS.morale.advanceAndPursue", {
+            name: this.data.name,
+          }),
+          12: game.i18n.format("ACKS.morale.fightToTheDeath", {
+            name: this.data.name,
+          }),
+        },
       },
     };
+
+    let skip = options.event && options.event.ctrlKey;
 
     // Roll and return
     return AcksDice.Roll({
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: true,
+      skipDialog: skip,
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.localize("ACKS.roll.morale"),
       title: game.i18n.localize("ACKS.roll.morale"),
@@ -184,26 +203,44 @@ export class AcksActor extends Actor {
   }
 
   rollLoyalty(options = {}) {
-    const label = game.i18n.localize(`ACKS.roll.loyalty`);
     const rollParts = ["2d6"];
+    rollParts.push(this.data.data.details.morale);
 
     const data = {
       actor: this.data,
       roll: {
-        type: "below",
-        target: this.data.data.retainer.loyalty,
+        type: "table",
+        table: {
+          1: game.i18n.format("ACKS.loyalty.hostility", {
+            name: this.data.name,
+          }),
+          3: game.i18n.format("ACKS.loyalty.resignation", {
+            name: this.data.name,
+          }),
+          6: game.i18n.format("ACKS.loyalty.grudging", {
+            name: this.data.name,
+          }),
+          9: game.i18n.format("ACKS.loyalty.loyal", {
+            name: this.data.name,
+          }),
+          12: game.i18n.format("ACKS.loyalty.fanatic", {
+            name: this.data.name,
+          }),
+        },
       },
     };
+
+    let skip = options.event && options.event.ctrlKey;
 
     // Roll and return
     return AcksDice.Roll({
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: true,
+      skipDialog: skip,
       speaker: ChatMessage.getSpeaker({ actor: this }),
-      flavor: label,
-      title: label,
+      flavor: game.i18n.localize("ACKS.loyalty.check"),
+      title: game.i18n.localize("ACKS.loyalty.check"),
     });
   }
 

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -16,7 +16,7 @@ export class AcksDice {
         result.isFailure = true;
       }
     } else if (data.roll.type == "below") {
-      // MORALE
+      // ?
       if (roll.total <= result.target) {
         result.isSuccess = true;
       } else {
@@ -35,7 +35,11 @@ export class AcksDice {
         roll._total = 1;
       }
     } else if (data.roll.type == "table") {
-      // Reaction
+      // Reaction, MORALE
+      // Roll cannot be less than 2 on a 2d6 roll
+      if (roll.total < 2) {
+        roll._total = 2
+      }
       let table = data.roll.table;
       let output = "";
       for (let i = 0; i <= roll.total; i++) {

--- a/src/template.json
+++ b/src/template.json
@@ -157,7 +157,7 @@
           "d": 0,
           "w": 0
         },
-        "morale": 7
+        "morale": 0
       },
       "attacks": ""
     }

--- a/src/templates/actors/partials/character-attributes-tab.html
+++ b/src/templates/actors/partials/character-attributes-tab.html
@@ -57,17 +57,6 @@
                         data-dtype="Number" />
                 </div>
             </li>
-            {{#if data.retainer.enabled}}
-            <li class="attribute ability-score" data-stat="lr">
-                <h4 class="attribute-name box-title" title="{{ localize 'ACKS.Loyalty' }}">
-                    <a>{{ localize "ACKS.LoyaltyShort" }}</a>
-                </h4>
-                <div class="attribute-value">
-                    <input name="data.retainer.loyalty" type="text" value="{{data.retainer.loyalty}}" placeholder="0"
-                        data-dtype="Number" />
-                </div>
-            </li>
-            {{/if}}
         </ul>
     </div>
     {{!-- Resource Tracking --}}

--- a/src/templates/actors/partials/character-header.html
+++ b/src/templates/actors/partials/character-header.html
@@ -30,7 +30,8 @@
         <label>{{localize 'ACKS.details.morale'}}</label>  
       </div>
     </li>
-    <li class="attribute ability-score" data-stat="lr">
+    <li class="flex2 check-field" data-stat="lr">
+      <div class="check loyalty-check" title="{{localize 'ACKS.loyalty.check'}}"><a><i class="fas fa-dice"></i></a></div>
       <div class="attribute-value">
         <input name="data.retainer.loyalty" type="text" value="{{data.retainer.loyalty}}" placeholder="Loyal" data-dtype="String" />
         <label>{{localize 'ACKS.Loyalty'}}</label>  

--- a/src/templates/actors/partials/character-header.html
+++ b/src/templates/actors/partials/character-header.html
@@ -22,6 +22,21 @@
          />
       <label>{{localize 'ACKS.details.alignment'}}</label>
     </li>
+    {{#if data.retainer.enabled}}
+    <li class="flexrow check-field">
+      <div class="check morale-check" title="{{localize 'ACKS.roll.morale'}}"><a><i class="fas fa-dice"></i></a></div>
+      <div>
+        <input type="text" name="data.details.morale" value="{{data.details.morale}}" />
+        <label>{{localize 'ACKS.details.morale'}}</label>  
+      </div>
+    </li>
+    <li class="attribute ability-score" data-stat="lr">
+      <div class="attribute-value">
+        <input name="data.retainer.loyalty" type="text" value="{{data.retainer.loyalty}}" placeholder="Loyal" data-dtype="String" />
+        <label>{{localize 'ACKS.Loyalty'}}</label>  
+      </div>
+    </li>
+    {{/if}}
   </ul>
   <ul class="summary flexrow">
     <li class="flex3">


### PR DESCRIPTION
On retainer sheets, Morale and Loyalty can now be rolled by clicking on their fields.
Morale should be a number (typically between -6 and +4) and Loyalty is a text field, in which the Judge can write things to remind him of any bonuses or penalties that need to be applied to the Morale or Loyalty check.
Morale rolls are made each time the henchman suffers a calamity. A calamity includes suffering an energy drain, a curse, a magical
disease, or being nearly killed (Judge’s discretion).
Loyalty rolls should make a morale roll for each henchman at the end of each adventure whenever the henchman has leveled up,
to determine if the henchman strikes off on his own or remains with the adventurer.