### PR TITLE
Fix encumbrance calculations

### DIFF
--- a/src/acks.css
+++ b/src/acks.css
@@ -900,15 +900,6 @@
   display: block;
   position: absolute;
 }
-.acks.sheet.actor.character .encumbrance .encumbrance-breakpoint.encumbrance-25 {
-  left: 24.4%;
-}
-.acks.sheet.actor.character .encumbrance .encumbrance-breakpoint.encumbrance-35 {
-  left: 34.4%;
-}
-.acks.sheet.actor.character .encumbrance .encumbrance-breakpoint.encumbrance-50 {
-  left: 49.4%;
-}
 .acks.sheet.actor.character .encumbrance .arrow-up {
   bottom: 0;
   width: 0;

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -50,7 +50,6 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
 
     data.config.ascendingAC = game.settings.get("acks", "ascendingAC");
     data.config.initiative = game.settings.get("acks", "initiative") != "group";
-    data.config.encumbrance = game.settings.get("acks", "encumbranceOption");
     data.config.BHR = game.settings.get("acks", "bhr");
     data.config.removeMagicBonus = game.settings.get("acks", "removeMagicBonus");
 

--- a/src/module/helpers.js
+++ b/src/module/helpers.js
@@ -23,11 +23,19 @@ export const registerHelpers = async function () {
   });
 
   Handlebars.registerHelper("subtract", function (lh, rh) {
-    return parseInt(rh) - parseInt(lh);
+    return parseInt(lh) - parseInt(rh);
   });
+
+  Handlebars.registerHelper("fsubtract", (lh, rh) => {
+    return parseFloat(lh) - parseFloat(rh);
+  })
 
   Handlebars.registerHelper("divide", function (lh, rh) {
     return Math.floor(parseFloat(lh) / parseFloat(rh));
+  });
+
+  Handlebars.registerHelper("fdivide", (lh, rh) => {
+    return parseFloat(lh) / parseFloat(rh);
   });
 
   Handlebars.registerHelper("mult", function (lh, rh) {

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -35,7 +35,7 @@
             {{/each}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.weight}}{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.data.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -87,7 +87,7 @@
             {{/if}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.weight}}{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.data.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -134,7 +134,7 @@
               placeholder="0" />{{#if item.data.quantity.max}}<span>/{{item.data.quantity.max}}</span>{{/if}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance "detailed")}}_{{else}}{{item.data.weight}}{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.data.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -157,7 +157,7 @@
       <div class="field-short"><i class="fas fa-hashtag"></i></div>
       <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
       <div class="item-controls">
-        <a class="item-control item-create" data-type="item" data-treasure="true" title="{{localize 'ACKS.Add'}}"><i
+        <a class="item-control item-create" data-type="item" data-treasure="true" data-weight=1000 title="{{localize 'ACKS.Add'}}"><i
             class="fa fa-plus"></i></a>
       </div>
     </li>
@@ -180,7 +180,7 @@
               placeholder="0" />{{#if item.data.quantity.max}}<span>/{{item.data.quantity.max}}</span>{{/if}}
           </div>
           <div class="field-short">
-            {{mult item.data.quantity.value item.data.weight}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{mult item.data.quantity.value item.data.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -200,12 +200,12 @@
   <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
     <span class="encumbrance-bar" style="width:{{pct}}%"></span>
     <span class="encumbrance-label">{{value}} / {{max}}</span>
-    <i class="encumbrance-breakpoint encumbrance-25 arrow-up"></i>
-    <i class="encumbrance-breakpoint encumbrance-25 arrow-down"></i>
-    <i class="encumbrance-breakpoint encumbrance-35 arrow-up"></i>
-    <i class="encumbrance-breakpoint encumbrance-35 arrow-down"></i>
-    <i class="encumbrance-breakpoint encumbrance-50 arrow-up"></i>
-    <i class="encumbrance-breakpoint encumbrance-50 arrow-down"></i>
+    <i class="encumbrance-breakpoint arrow-up" style="left: {{fsubtract (mult (fdivide 5000 max) 100) 1}}%"></i>
+    <i class="encumbrance-breakpoint arrow-down" style="left: {{fsubtract (mult (fdivide 5000 max) 100) 1}}%"></i>
+    <i class="encumbrance-breakpoint arrow-up" style="left: {{fsubtract (mult (fdivide 7000 max) 100) 1}}%"></i>
+    <i class="encumbrance-breakpoint arrow-down" style="left: {{fsubtract (mult (fdivide 7000 max) 100) 1}}%"></i>
+    <i class="encumbrance-breakpoint arrow-up" style="left: {{fsubtract (mult (fdivide 10000 max) 100) 1}}%"></i>
+    <i class="encumbrance-breakpoint arrow-down" style="left: {{fsubtract (mult (fdivide 10000 max) 100) 1}}%"></i>
     {{/with}}
   </div>
 </section>


### PR DESCRIPTION
This is titled "fix" but it's more of an overhaul of how encumbrance is calculated using the core ACKS rules. Dead code that referred to nonexistent encumbrance options was culled, and the logic behind the total encumbrance was changed to be more intuitive with how the rules are written. Heavy/treasure items are now created with 1000 weight by default.

New encumbrance logic:

- Normal items *don't* count their quantity when calculating total encumbrance.
- Heavy/treasure items *do* count their quantity when calculating total encumbrance.
- Weapons/armor *don't* count their quantity when calculating total encumbrance.
- When using the "Complete" encumbrance option (i.e. every item weighs 1000 coins per stone), the item's weight is ignored and 1000 is used instead.

Additionally, the rules specified the following regarding maximum encumbrance:

> The maximum any character can carry is 20 stone, plus his Strength adjustment.

I modified the maximum encumbrance to be calculated based on the character's Strength modifier. I reworked the character movement encumbrance arrows to calculate their position based on the maximum encumbrance value so that they weren't static.

The movement speed calculations also had dead code, so all of that was removed and simplified.